### PR TITLE
remove postgresql_backup role from collection

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: infra_monkey
 name: ansible_general
-version: 0.0.5
+version: 0.0.6
 
 readme: README.md
 authors:


### PR DESCRIPTION
 postgresql_backup role  is not very general purpose. removing it from the collection.
It is still available as a galaxy role